### PR TITLE
Fix dataloading for odd length datasets

### DIFF
--- a/upsnet/upsnet_end2end_test.py
+++ b/upsnet/upsnet_end2end_test.py
@@ -62,8 +62,6 @@ def im_detect(output_all, data, im_infos):
     pred_pano_cls_inds_all = []
     cls_inds_all = []
 
-    if len(data) == 1:
-        output_all = [output_all]
 
     output_all = [{k: v.data.cpu().numpy() for k, v in output.items()} for output in output_all]
 

--- a/upsnet/upsnet_end2end_test.py
+++ b/upsnet/upsnet_end2end_test.py
@@ -231,9 +231,7 @@ def upsnet_test():
                 for k, v in data.items():
                     data[k] = v.pin_memory().to(gpu_id, non_blocking=True) if torch.is_tensor(v) else v
             except StopIteration:
-                data = data.copy()
-                for k, v in data.items():
-                    data[k] = v.pin_memory().to(gpu_id, non_blocking=True) if torch.is_tensor(v) else v
+                break
             batch.append((data, None))
             labels.append(label)
             i_iter += 1


### PR DESCRIPTION
If you have a configuration where the number of GPUs does not evenly divide the dataset the except branch tries to pin a CUDA tensor.